### PR TITLE
Fix TypeError on dates with no event

### DIFF
--- a/scripts/events.js
+++ b/scripts/events.js
@@ -66,8 +66,10 @@ function calculate_event() {
         data = events["months"][month];
     }
 
-    update_icons(data[0]);
-    update_desc(data[1]);
+    if (data != undefined) {
+        update_icons(data[0]);
+        update_desc(data[1]);
+    }
 }
 
 /**


### PR DESCRIPTION
calculate_event() was attempting to update the icons and descriptions with event-specific data even on dates there is no defined event for. While this didn't cause anything to break, it did log a TypeError in the console that doesn't need to be there. Fixed by a simple null value check.
