### PR TITLE
Fix main-content skip text being invisible

### DIFF
--- a/styles/categories/decoration.css
+++ b/styles/categories/decoration.css
@@ -14,7 +14,7 @@ button.is-danger:hover {
 
 /* COOKIE BANNER */
 #cookie-banner {
-    background-color: var(--cookie-banner-background);
+    background-color: var(--bulma-scheme-main);
     border: var(--border-dull);
     border-radius: 5px;
 }
@@ -30,6 +30,10 @@ button.is-danger:hover {
 }
 .navbar-brand a {
     cursor: default !important;
+}
+#skip-link {
+    background-color: var(--bulma-scheme-main);
+    color: var(--bulma-text);
 }
 #theme-button {
     font-size: 20px;

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -7,7 +7,6 @@
 }
 
 html[data-theme="dark"] {
-    --cookie-banner-background: #14161a;
     --description-colour: #fff;
     --link-colour: #5c7aff;
     --link-colour-hover: var(--bulma-info);
@@ -15,9 +14,8 @@ html[data-theme="dark"] {
 }
 
 html[data-theme="light"] {
-    --cookie-banner-background: #fff;
     --description-colour: #000;
-    --footer-colour: white;
+    --footer-colour: #fff;
     --link-colour: #485fc7;
     --link-colour-hover: #363636;
     --navbar-clickable-colour: #404654;


### PR DESCRIPTION
The text for the main-content skip link was invisible, being white on a wwhite background. This has been fixed, and some unnecessary variables that mirrored values Bulma already has variables for were removed and replaced with those Bulma variables.
